### PR TITLE
Add SystemInfoModule

### DIFF
--- a/Packages/com.witalosk.unistats/Prefabs/Modules/SystemInfoModule.prefab
+++ b/Packages/com.witalosk.unistats/Prefabs/Modules/SystemInfoModule.prefab
@@ -1,0 +1,61 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4344924448165974093
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2888787701930454302}
+  - component: {fileID: 6568731100009936050}
+  - component: {fileID: 6388382373584936436}
+  m_Layer: 0
+  m_Name: SystemInfoModule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2888787701930454302
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4344924448165974093}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6568731100009936050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4344924448165974093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 652d06bcbdee4254c809de166e3518c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _moduleTreeAsset: {fileID: 9197481963319205126, guid: d4aa3bf573e1d1b4385de174aaa4ce37, type: 3}
+  _moduleName: System Info
+--- !u!114 &6388382373584936436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4344924448165974093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 544bc57be0a2c1c4d886753478298d7f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.witalosk.unistats/Prefabs/Modules/SystemInfoModule.prefab.meta
+++ b/Packages/com.witalosk.unistats/Prefabs/Modules/SystemInfoModule.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 693a5396f25cdea4fa95d044aa9a8baa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.witalosk.unistats/Prefabs/UniStats.prefab
+++ b/Packages/com.witalosk.unistats/Prefabs/UniStats.prefab
@@ -35,6 +35,7 @@ Transform:
   - {fileID: 7702004306104022601}
   - {fileID: 1956795052608103969}
   - {fileID: 537779314485192054}
+  - {fileID: 2088264583270987811}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7702004306534041667
@@ -196,6 +197,68 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 5444478349371107505, guid: d4b9b50f5d6926445b96986205befbdb, type: 3}
   m_PrefabInstance: {fileID: 2408766276084040276}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3813432395016803645
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7702004306534041665}
+    m_Modifications:
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4344924448165974093, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+      propertyPath: m_Name
+      value: SystemInfoModule
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+--- !u!4 &2088264583270987811 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2888787701930454302, guid: 693a5396f25cdea4fa95d044aa9a8baa, type: 3}
+  m_PrefabInstance: {fileID: 3813432395016803645}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5690255498407694381
 PrefabInstance:

--- a/Packages/com.witalosk.unistats/Runtime/GraphRenderer/GraphRendererBase.cs
+++ b/Packages/com.witalosk.unistats/Runtime/GraphRenderer/GraphRendererBase.cs
@@ -31,11 +31,15 @@ namespace UniStats
         {
             IsInited = false;
             
-            if (_graphTexture != null)
+            if (_graphTexture == null) return;
+
+            if (RenderTexture.active == _graphTexture)
             {
-                _graphTexture.Release();
-                _graphTexture = null;
+                RenderTexture.active = null;
             }
+                
+            _graphTexture.Release();
+            _graphTexture = null;
         }
     }
 }

--- a/Packages/com.witalosk.unistats/Runtime/Modules/SystemInfoProvider.cs
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/SystemInfoProvider.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using UnityEngine;
+
+namespace UniStats
+{
+    public class SystemInfoProvider : MonoBehaviour, ITextProvider
+    {
+        public string Text => _text;
+
+        private string _text;
+        private Vector2Int _currentScreenWindowResolution = new();
+        private readonly StringBuilder _textBuilder = new();
+
+        private void BuildText()
+        {
+            _textBuilder.Clear();
+            _currentScreenWindowResolution.x = Screen.width;
+            _currentScreenWindowResolution.y = Screen.height;
+            var res = Screen.currentResolution;
+            
+            // ScreenResolution
+            _textBuilder.AppendLine("Screen: "
+                                    + res.width
+                                    + "x"
+                                    + res.height
+                                    + "@"
+                                    +  Mathf.RoundToInt((float)res.refreshRateRatio.value)
+                                    + "Hz");
+            
+            // ScreenWindowResolution
+            _textBuilder.AppendLine("Window: "
+                                    + _currentScreenWindowResolution.x
+                                    + "x"
+                                    + _currentScreenWindowResolution.y
+                                    + "@"
+                                    + Mathf.RoundToInt((float)res.refreshRateRatio.value)
+                                    + "Hz["
+                                    + (int)Screen.dpi
+                                    + "dpi]");
+            
+            // GraphicsDeviceVersion
+            _textBuilder.AppendLine("Graphics API: "
+                                    + SystemInfo.graphicsDeviceVersion);
+            
+            // GraphicsDeviceName
+            _textBuilder.AppendLine("GPU: "
+                                    + SystemInfo.graphicsDeviceName);
+            
+            // GraphicsMemorySize
+            _textBuilder.AppendLine("VRAM: "
+                                    + SystemInfo.graphicsMemorySize
+                                    + "MB. Max texture size: "
+                                    + SystemInfo.maxTextureSize
+                                    + "px. Shader level: "
+                                    + SystemInfo.graphicsShaderLevel);
+            
+            // ProcessorType
+            _textBuilder.AppendLine("CPU: "
+                                    + SystemInfo.processorType
+                                    + " ["
+                                    + SystemInfo.processorCount
+                                    + " cores]");
+            
+            // SystemMemorySize
+            _textBuilder.AppendLine("RAM: "
+                                    + SystemInfo.systemMemorySize
+                                    + " MB");
+            
+            // OperationSystem
+            _textBuilder.Append("OS: "
+                                    + SystemInfo.operatingSystem
+                                    + " ["
+                                    + SystemInfo.deviceType
+                                    + "]");
+            
+            _text = _textBuilder.ToString();
+        }
+        
+        public void Init()
+        {
+            BuildText();
+        }
+
+        private void Update()
+        {
+            if (_currentScreenWindowResolution.x != Screen.width || _currentScreenWindowResolution.y != Screen.height)
+            {
+                BuildText();
+            }
+        }
+
+        private void OnDestroy()
+        {
+            _textBuilder.Clear();
+        }
+    }
+}

--- a/Packages/com.witalosk.unistats/Runtime/Modules/SystemInfoProvider.cs.meta
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/SystemInfoProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 544bc57be0a2c1c4d886753478298d7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.witalosk.unistats/Runtime/Modules/TextModule.meta
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/TextModule.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 666aa368b28f4b547acaacc4da2025a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/ITextProvider.cs
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/ITextProvider.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UniStats
+{
+    public interface ITextProvider
+    {
+        string Text { get; }
+        void Init();
+    }
+}

--- a/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/ITextProvider.cs.meta
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/ITextProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb7857dd463756b439a5e12b8e50bcfa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/TextModule.cs
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/TextModule.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace UniStats
+{
+    public class TextModule : ModuleBase
+    {
+        [SerializeField] private int _fontSize = 7;
+        
+        private Label _label;
+        private ITextProvider _textProvider;
+
+        public override void Init()
+        {
+            base.Init();
+
+            _textProvider = GetComponent<ITextProvider>();
+            _textProvider.Init();
+            
+            _label = ModuleElementRoot.Q<Label>("Text");
+            _label.text = _textProvider.Text;
+        }
+
+        private void Update()
+        {
+            _label.text = _textProvider.Text;
+            _label.style.fontSize = _fontSize;
+        }
+    }
+}

--- a/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/TextModule.cs.meta
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/TextModule/TextModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 652d06bcbdee4254c809de166e3518c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.witalosk.unistats/Runtime/UIToolkit/StatsViewerRoot.uxml
+++ b/Packages/com.witalosk.unistats/Runtime/UIToolkit/StatsViewerRoot.uxml
@@ -1,4 +1,4 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Packages/com.witalosk.unistats/Runtime/UIToolkit/USS/StatsViewer.uss?fileID=7433441132597879392&amp;guid=4ae796a486d164b40b9af7ff390864d4&amp;type=3#StatsViewer" />
-    <ui:GroupBox name="StatsViewerRoot" picking-mode="Ignore" class="rootBox" />
+    <ui:GroupBox name="StatsViewerRoot" picking-mode="Ignore" class="rootBox" style="width: auto; min-width: 250px;" />
 </ui:UXML>

--- a/Packages/com.witalosk.unistats/Runtime/UIToolkit/TextModule.uxml
+++ b/Packages/com.witalosk.unistats/Runtime/UIToolkit/TextModule.uxml
@@ -1,0 +1,7 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Packages/com.witalosk.unistats/Runtime/UIToolkit/USS/StatsViewer.uss?fileID=7433441132597879392&amp;guid=4ae796a486d164b40b9af7ff390864d4&amp;type=3#StatsViewer" />
+    <ui:GroupBox name="TextModuleBox" class="moduleBox" style="height: auto; visibility: visible; overflow: hidden; width: auto; -unity-text-align: middle-left;">
+        <ui:Label text="SystemInfo" display-tooltip-when-elided="true" name="ModuleLabel" class="moduleName svText" />
+        <ui:Label text="Screen: ####x####@##Hz&#10;Window: ####x####@##Hz[##dpi]&#10;Graphics API: #####&#10;GPU: #####&#10;VRAM: #####MB. Max texture size: #####px. Shader level: ##&#10;CPU: ##### [## cores]&#10;RAM: ##### MB&#10;OS: ##### [#####]" name="Text" style="flex-grow: 1; align-self: auto; color: rgb(204, 204, 204); -unity-text-align: middle-left; flex-shrink: 0; white-space: normal;" />
+    </ui:GroupBox>
+</ui:UXML>

--- a/Packages/com.witalosk.unistats/Runtime/UIToolkit/TextModule.uxml.meta
+++ b/Packages/com.witalosk.unistats/Runtime/UIToolkit/TextModule.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d4aa3bf573e1d1b4385de174aaa4ce37
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
# Add SystemInfoModule

<img width="496" height="529" alt="image" src="https://github.com/user-attachments/assets/ff44e632-1a83-47bb-906a-3744f3dee6c7" />

## Change

- `TextModule`を追加
    - InspectorよりFontSizeを指定可能、デフォルトは7

https://github.com/user-attachments/assets/1751d2d8-0e8f-42e4-a6c1-6a70bd998ac3

- `SystemInfoProvider`を追加
    - 初期化時とWindoow解像度がPlay中に変更された時にSystemInfoを取得しテキストをビルドする
- `StatsViewerRoot.uxml`の`width`を250pxからautoに、`min-width`をautoから250pxに変更

## Fix

<img width="353" height="29" alt="image" src="https://github.com/user-attachments/assets/dc343039-ac04-4e9f-a5b6-a6bf7de54e8b" />

- UIのサイズが更新されるときに`RenderTexture.active`にセットされているテクスチャがリリースされないように修正