### PR TITLE
v1.4.1 - fixed a bug in SystemInfoProvider

### DIFF
--- a/Packages/com.witalosk.unistats/CHANGELOG.md
+++ b/Packages/com.witalosk.unistats/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## [1.4.1] - 2025-10-16
+### Bug Fixes
+- Fixed an issue where SystemInfoProvider did not function in versions prior to 2022.1.
+
 ## [1.4.0] - 2025-07-11
 ### Changes
 - Added Text Module (System Info Module).

--- a/Packages/com.witalosk.unistats/Runtime/Modules/SystemInfoProvider.cs
+++ b/Packages/com.witalosk.unistats/Runtime/Modules/SystemInfoProvider.cs
@@ -17,35 +17,43 @@ namespace UniStats
             _currentScreenWindowResolution.x = Screen.width;
             _currentScreenWindowResolution.y = Screen.height;
             var res = Screen.currentResolution;
-            
+
             // ScreenResolution
             _textBuilder.AppendLine("Screen: "
                                     + res.width
                                     + "x"
                                     + res.height
                                     + "@"
+#if UNITY_2022_2_OR_NEWER
                                     +  Mathf.RoundToInt((float)res.refreshRateRatio.value)
+#else
+                                    +  res.refreshRate
+#endif
                                     + "Hz");
-            
+
             // ScreenWindowResolution
             _textBuilder.AppendLine("Window: "
                                     + _currentScreenWindowResolution.x
                                     + "x"
                                     + _currentScreenWindowResolution.y
                                     + "@"
-                                    + Mathf.RoundToInt((float)res.refreshRateRatio.value)
+#if UNITY_2022_2_OR_NEWER
+                                    +  Mathf.RoundToInt((float)res.refreshRateRatio.value)
+#else
+                                    +  res.refreshRate
+#endif
                                     + "Hz["
                                     + (int)Screen.dpi
                                     + "dpi]");
-            
+
             // GraphicsDeviceVersion
             _textBuilder.AppendLine("Graphics API: "
                                     + SystemInfo.graphicsDeviceVersion);
-            
+
             // GraphicsDeviceName
             _textBuilder.AppendLine("GPU: "
                                     + SystemInfo.graphicsDeviceName);
-            
+
             // GraphicsMemorySize
             _textBuilder.AppendLine("VRAM: "
                                     + SystemInfo.graphicsMemorySize
@@ -53,29 +61,29 @@ namespace UniStats
                                     + SystemInfo.maxTextureSize
                                     + "px. Shader level: "
                                     + SystemInfo.graphicsShaderLevel);
-            
+
             // ProcessorType
             _textBuilder.AppendLine("CPU: "
                                     + SystemInfo.processorType
                                     + " ["
                                     + SystemInfo.processorCount
                                     + " cores]");
-            
+
             // SystemMemorySize
             _textBuilder.AppendLine("RAM: "
                                     + SystemInfo.systemMemorySize
                                     + " MB");
-            
+
             // OperationSystem
             _textBuilder.Append("OS: "
                                     + SystemInfo.operatingSystem
                                     + " ["
                                     + SystemInfo.deviceType
                                     + "]");
-            
+
             _text = _textBuilder.ToString();
         }
-        
+
         public void Init()
         {
             BuildText();

--- a/Packages/com.witalosk.unistats/package.json
+++ b/Packages/com.witalosk.unistats/package.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "com.witalosk.unistats",
   "displayName": "UniStats",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "unity": "2021.1",
   "description": "Simple Stats Viewer based on UIToolkit",
   "author": {


### PR DESCRIPTION
This pull request addresses a compatibility bug in the `SystemInfoProvider` module, ensuring correct functionality across different Unity versions. The main change is a fix for how screen refresh rates are retrieved, making the code work for both newer and older Unity versions. The package version has also been updated to reflect this bug fix.

Bug Fixes and Compatibility:

* Updated `SystemInfoProvider.cs` to use `refreshRateRatio.value` for Unity 2022.2 or newer, and fallback to `refreshRate` for earlier versions, ensuring compatibility with Unity versions prior to 2022.1. [[1]](diffhunk://#diff-baaa7ba5db1d8a46c8c64d0a72d47c25eafc0d1e2adaa2c3e94f3ee1cc709e21R27-R31) [[2]](diffhunk://#diff-baaa7ba5db1d8a46c8c64d0a72d47c25eafc0d1e2adaa2c3e94f3ee1cc709e21R40-R44)
* Added a bug fix entry to the `CHANGELOG.md` for version 1.4.1, documenting the resolution of the issue with `SystemInfoProvider` on older Unity versions.

Version Update:

* Bumped the package version to `1.4.1` in `package.json` to reflect the bug fix release.